### PR TITLE
Update TTWG home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
                       rel="nofollow">TTWG Dashboard issues</a></li>
                   <li><a href="https://labs.w3.org/unitas/?g=34314">Unitas</a></li>
                   <li><a href="https://www.w3.org/wiki/TimedText">Wiki</a></li>
+                  <li><a href="https://www.w3.org/wiki/TimedText/Publications">Publications</a></li>
                   <li><a href="https://www.w3.org/2018/05/timed-text-charter.html">Charter</a></li>
                   <li><a href="https://www.w3.org/2000/09/dbwg/details?group=34314"><span
 
@@ -77,24 +78,7 @@
         based on implementation experience and interoperability feedback, and
         the creation of semantic mappings between those languages.</p>
       <!--
-<h2 class="break" id="news">Upcoming Talks</h2><p>The 24th Annual International Technology and Persons withDisabilities Conference will be held on March 16-21, 2009 at the LosAngeles Airport Marriott &amp; Renaissance Montura Hotels.</p><p>It will include the following talks related to DFXP 1.0:</p><ul><li>March 19: <a href='http://www.csunconference.org/index.cfm?EID=80000144&amp;p=90&amp;page=scheduledetail&amp;LCID=2947&amp;ECTID=0'>Accessible, Usable, Searchable On-line Video</a>, Geoff Freed, WGBH National Center for Accessible Media</li><li>March 20: <a href='http://www.csunconference.org/index.cfm?EID=80000144&amp;p=90&amp;page=scheduledetail&amp;LCID=3270&amp;ECTID=0'>Video for Everyone: Accessible Video with Flash</a>, Andrew Kirkpatrick, Adobe Systems, and <a href='http://www.csunconference.org/index.cfm?EID=80000144&amp;p=90&amp;page=scheduledetail&amp;LCID=2948&amp;ECTID=0'>Captioning Solutions for Handheld Media and Mobile Devices</a>, Geoff Freed, WGBH National Center for Accessible Media</li><li>March 21: <a href='http://www.csunconference.org/index.cfm?EID=80000144&amp;p=90&amp;page=scheduledetail&amp;LCID=2965&amp;ECTID=0'>Developing Accessible Media Applications for the Web Using Microsoft Silverlight 2.0</a>, Sean Hayes, Microsoft</li></ul>-->
-      <h2 class="break">Emmy Award</h2>
-      <p>The W3C TTWG was rewarded with a Technology &amp; Engineering Emmy
-        Award from the National Academy of Television Arts &amp; Sciences
-        (NATAS) for its Timed Text Mark-up Language (TTML1) in category
-        "Standardization and Pioneering Development of Non-Live Broadband
-        Captioning", on 08th January 2016 at the Bellagio in Las Vegas. </p>
-      <p> </p>
-      <figure> <img title="TTWG and Emmy Award" alt="TTWG and Emmy Award" src="https://www.w3.org/2016/01/Emmy/small/MDB_5529-TTWG-Emmy-1.jpg"
 
-          width="700" /> <figcaption class="caption"> [left to right]: Glenn
-          Adams (Skynav), Mike Dolan (SMPTE), Philippe Le Hégaret (W3C), Thierry
-          Michel W3C).</figcaption> </figure>
-      <p></p>
-      <p><a href="https://www.w3.org/2016/01/emmyawardttml.html.en">Press
-          Release</a> and more <a title="Emmy Award ceremony" href="https://www.w3.org/2016/01/Emmy/">pictures
-          and video of the Emmy Award ceremony</a> are available. <br />
-      </p>
       <h2 id="docs" class="break">Timed text WG activities</h2>
       Refer to the <a href="https://www.w3.org/wiki/TimedText"><span style="font-weight: bold;">TTWG
           wiki</span></a> to learn more about the TTWG Working group <span id="Timed_Text_Efforts_and_Specifications"
@@ -135,11 +119,14 @@
         <li>the <a href="http://dev.w3.org/cvsweb/2008/tt/testsuite/">CVS
             repository</a> where everything comes from.</li>
       </ul>
-      <p>For WebVTT, the test suite is part of <a href="https://github.com/web-platform-tests/wpt/tree/master/webvtt">web-platform-tests</a>.</p>
       <!-- h2 class="break" id="demos">Demonstrations</h2>
       <ul>        <li><a href="/2009/02/ThisIsCoffee.html">DFXP with caffeine</a>: this          (old) demo requires a browser that supports the HTML 5 video element,          its Media API, and the Ogg or MPEG-4 video codecs.</li>        <li>@@put here a demo for WebVTT</li>      </ul>      <h2 class="break" id="records">Meeting records</h2>      <p>Search for <a href="https://www.w3.org/Search/Mail/Public/search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=minutes&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=public-tt">minutesin          the mailing list archive</a>. </p>      <p>See also the previous records:</p>      <ul>        <li><a href="minutes.html#tel-minutes">Telecon Minutes</a></li>        <li><a href="minutes.html#f2f-minutes">Face to Face Meeting Minutes</a></li>      </ul -->
+      <h2 id="cepc">Code of Ethics and Professional Conduct</h2>
+      <p>The <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics 
+      and Professional Conduct</a> applies to all TTWG work.</p>
       <h2 class="break" id="lists">Discussion lists</h2>
-      <p>Technical discussion takes place on the Working Group discussion list,
+      <p>Technical discussion takes place on GitHub repository issues and pull 
+        requests and on the Working Group discussion list,
         public-tt@w3.org (<a href="http://lists.w3.org/Archives/Public/public-tt/">archive</a>).
         This is a public mailing list; to <a href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe
           to the public-tt mailing list</a>, please check the <a href="../../../Mail/Request">subscription
@@ -153,10 +140,47 @@
 
 type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="search">help</a></p>
       </form>
+      <p>The TTWG also maintains the <a href="https://www.w3.org/wiki/TimedText">
+        Timed Text wiki</a> which includes a list of the TTWG's
+        <a href="https://www.w3.org/wiki/TimedText/Publications">publications</a>.</p>
       <!--h2 class="break"><a name="Background">Background/Historical</a></h2>
       <ul>        <li><a href="https://www.w3.org/AudioVideo/timetext.html">Timed-Text            initial requirement document draft</a> (edited by the <a href="http://lists.w3.org/Archives/Public/www-tt-tf/">Timed-Text            Task Force</a>)</li>        <li><a href="https://www.w3.org/2003/01/Timed-text-Patent-statements.html">Previous            Timed-Text IPR public page</a></li>        <li><a href="https://www.w3.org/AudioVideo/timetext.html">Timed-Text            Requirements document initial draft</a> (edited by the <a href="http://lists.w3.org/Archives/Public/www-tt-tf/">Timed-Text            task force</a>)</li>        <li><a href="https://www.w3.org/AudioVideo/TT/Group/">W3C Timed-Text            Working Group</a> (<a href="https://www.w3.org/Help/AccessForm">members            only</a>)</li>        <li>Timed-Text task force list <a href="mailto:www-tt-tf@w3.org">www-tt-tf@w3.org</a>          (<a href="http://lists.w3.org/Archives/Public/www-tt-tf/">archives</a>)</li>        <li><a href="/AudioVideo/Group/TT-activity.html">Timed-Text Activity            Proposal</a> (<a href="https://www.w3.org/Help/AccessForm">members            only</a>)</li>      </ul -->
       <!--
 <h2>Tutorials</h2><ul>  <li><a    href="http://audio-video-images.indelv.com/timed-text-the-basics.html">What    is Timed Text?</a></li></ul>-->
+      <h2 id="meetings">Meetings</h2>
+      <p>Meetings are held at 1600 UTC (winter time, where it applies) weekly on
+      Thursdays, duration 1 hour. By exception 2 hour meetings may be scheduled,
+      beginning at 1500 UTC. In summer time, meetings begin 1 hour earlier in UTC time.</p>
+      <p>Upcoming meetings are visible at the 
+      <a href="https://github.com/w3c/ttwg/projects/1">TTWG project dashboard</a>.</p>
+      <h2 id="recent-activity">Recent Activity and list of repositories</h2>
+      <p>Recent activity can be found on the following repository links:</p>
+      <h3>Group repositories</h3>
+      <ul>
+        <li><a href="https://github.com/w3c/ttwg/pulse">TTWG business</a></li>
+        <li><a href="https://github.com/w3c/tt-reqs/pulse">TTWG future requirements</a></li>
+      </ul>
+      <h3>Recommendation Track specification repositories</h3>
+      <ul>
+        <li><a href="https://github.com/w3c/imsc/pulse">IMSC</a></li>
+        <li><a href="https://github.com/w3c/ttml1/pulse">TTML1</a></li>
+        <li><a href="https://github.com/w3c/ttml2/pulse">TTML2</a></li>
+        <li><a href="https://github.com/w3c/webvtt/pulse">WebVTT</a></li>
+      </ul>
+      <h3>Test repositories</h3>
+      <ul>
+        <li><a href="https://github.com/w3c/imsc-tests/pulse">IMSC Tests</a></li>
+        <li><a href="https://github.com/w3c/ttml1-tests/pulse">TTML1 tests</a></li>
+        <li><a href="https://github.com/w3c/ttml2-tests/pulse">TTML2 tests</a></li>
+        <li><a href="https://github.com/web-platform-tests/wpt/tree/master/webvtt">WebVTT tests<a> (on Web Platform Tests)</li>
+      </ul>
+      <h3>Working Group Notes, registries etc</h3>
+      <ul>
+        <li><a href="https://github.com/w3c/imsc-vnext-reqs/pulse">IMSC vNext Requirements</a></li>
+        <li><a href="https://github.com/w3c/png-hdr-pq/pulse">PQ HDR in PNG</a></li>
+        <li><a href="https://github.com/w3c/tt-profile-registry/pulse">TTML Profile Registry</a></li>
+        <li><a href="https://github.com/w3c/ttml-webvtt-mapping/pulse">TTML to WebVTT mapping</a></li>
+      </ul>
       <h2 id="join">How to join the group</h2>
       <p>This group operates under the <a href="https://www.w3.org/2003/12/22-pp-faq.html">W3C
           Patent Policy</a>, which ensures that specifications published by the


### PR DESCRIPTION
Remove Emmy award, add CEPC, Meetings and Repositories.