### PR TITLE
2023 charter, URL updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
                   <li><a href="https://www.w3.org/PM/Groups/chairboard.html?gid=34314">Chair dashboard</a></li>
                   <li><a href="https://www.w3.org/wiki/TimedText">Wiki</a></li>
                   <li><a href="https://www.w3.org/groups/wg/timed-text/publications">Publications</a></li>
-                  <li><a href="https://www.w3.org/2020/12/timed-text-wg-charter.html">Charter</a></li>
+                  <li><a href="https://www.w3.org/2023/04/timed-text-wg-charter.html">Charter</a></li>
                   <li><a href="https://www.w3.org/groups/wg/timed-text/participants"><span
 
                         style="color: #0000ee;"><span style="text-decoration: underline;">TTWG
@@ -170,11 +170,11 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
       <h3>Recommendation Track specification repositories</h3>
       <ul>
         <li><a href="https://github.com/w3c/imsc/pulse">IMSC</a></li>
+        <li><a href="https://github.com/w3c/imsc-hrm">IMSC Hypothetical Render Model (HRM)</a></li>
         <li><a href="https://github.com/w3c/ttml1/pulse">TTML1</a></li>
         <li><a href="https://github.com/w3c/ttml2/pulse">TTML2</a></li>
-        <li><a href="https://github.com/w3c/ttml3/pulse">TTML3</a></li>
         <li><a href="https://github.com/w3c/webvtt/pulse">WebVTT</a></li>
-        <li><a href="https://github.com/w3c/adpt/pulse">ADPT</a></li>
+        <li><a href="https://github.com/w3c/dapt">Dubbing and Audio description Profiles of TTML2 (DAPT)</a></li>
         <li><a href="https://github.com/w3c/tt-module-cjk-ext-1/pulse">TTML CJK Extension Module 1</a></li>
         <li><a href="https://github.com/w3c/tt-module-css/pulse">TTML CSS Extension Module</a> <span class="small">(not currently actively being worked on)</span></li>
         <li><a href="https://github.com/w3c/tt-module-karaoke/pulse">TTML Karaoke Extension Module</a></li>
@@ -184,6 +184,7 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
       <h3>Test repositories</h3>
       <ul>
         <li><a href="https://github.com/w3c/imsc-tests/pulse">IMSC Tests</a></li>
+        <li><a href="https://github.com/w3c/imsc-hrm-tests">IMSC Hypothetical Render Model (HRM) Tests</a></li>
         <li><a href="https://github.com/w3c/IMSC-1.0.1_Text_TestContent/pulse">Test contents for IMSC 1.0.1 Text</a></li>
         <li><a href="https://github.com/w3c/IMSC-1.1_Text_TestContent/pulse">Test contents for IMSC 1.1 Text</a></li>
         <li><a href="https://github.com/w3c/IMSC-1.1_Image_TestContent/pulse">Test contents for IMSC 1.1 Image</a></li>
@@ -197,9 +198,15 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
         <li><a href="https://github.com/w3c/png-hdr-pq/pulse">PQ HDR in PNG</a></li>
         <li><a href="https://github.com/w3c/tt-profile-registry/pulse">TTML Profile Registry</a></li>
         <li><a href="https://github.com/w3c/ttml-webvtt-mapping/pulse">TTML to WebVTT mapping</a></li>
+        <li><a href="https://github.com/w3c/dapt-reqs">Requirements on Dubbing and Audio description Profiles of TTML2 (DAPT)</a></li>
+      </ul>
+      <h3>Suspended Recommendation Track specification repositories</h3>
+      <ul>
+        <li><a href="https://github.com/w3c/ttml3/pulse">TTML3</a></li>
+        <li><a href="https://github.com/w3c/adpt/pulse">ADPT</a></li>
       </ul>
       <h2 id="join">How to join the group</h2>
-      <p>This group operates under the <a href="https://www.w3.org/2003/12/22-pp-faq.html">W3C
+      <p>This group operates under the <a href="https://www.w3.org/2020/09/15-pp-faq.html">W3C
           Patent Policy</a>, which ensures that specifications published by the
         group can be implemented on a royalty-free (RF) basis. To record
         agreement from all participants with that W3C Patent Policy, joining the
@@ -208,10 +215,10 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
         <li> If you're affiliated with a <a href="https://www.w3.org/Consortium/Member/List">W3C
             member organization</a>
           <ol>
-            <li>Use the <a href="http://cgi.w3.org/MemberAccess/AccessRequest">form
+            <li>Use the <a href="https://www.w3.org/accounts/request">form
                 for getting a W3C account</a></li>
             <li>Have your <a href="https://www.w3.org/Member/ACList">AC
-                representative</a> nominate you using the <a href="https://www.w3.org/2004/01/pp-impl/34314/join">form
+                representative</a> nominate you using the <a href="https://www.w3.org/groups/wg/timed-text/join">form
                 for joining this Working Group</a>.</li>
           </ol>
         </li>

--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
         <li><a href="https://github.com/w3c/png-hdr-pq/pulse">PQ HDR in PNG</a></li>
         <li><a href="https://github.com/w3c/tt-profile-registry/pulse">TTML Profile Registry</a></li>
         <li><a href="https://github.com/w3c/ttml-webvtt-mapping/pulse">TTML to WebVTT mapping</a></li>
-        <li><a href="https://github.com/w3c/dapt-reqs">Requirements on Dubbing and Audio description Profiles of TTML2 (DAPT)</a></li>
+        <li><a href="https://github.com/w3c/dapt-reqs/pulse">Requirements for the Dubbing and Audio description Profiles of TTML2 (DAPT)</a></li>
       </ul>
       <h3>Suspended Recommendation Track specification repositories</h3>
       <ul>

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
         <li><a href="https://github.com/w3c/ttml1/pulse">TTML1</a></li>
         <li><a href="https://github.com/w3c/ttml2/pulse">TTML2</a></li>
         <li><a href="https://github.com/w3c/webvtt/pulse">WebVTT</a></li>
-        <li><a href="https://github.com/w3c/dapt">Dubbing and Audio description Profiles of TTML2 (DAPT)</a></li>
+        <li><a href="https://github.com/w3c/dapt/pulse">Dubbing and Audio description Profiles of TTML2 (DAPT)</a></li>
         <li><a href="https://github.com/w3c/tt-module-cjk-ext-1/pulse">TTML CJK Extension Module 1</a></li>
         <li><a href="https://github.com/w3c/tt-module-css/pulse">TTML CSS Extension Module</a> <span class="small">(not currently actively being worked on)</span></li>
         <li><a href="https://github.com/w3c/tt-module-karaoke/pulse">TTML Karaoke Extension Module</a></li>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
       <h3>Test repositories</h3>
       <ul>
         <li><a href="https://github.com/w3c/imsc-tests/pulse">IMSC Tests</a></li>
-        <li><a href="https://github.com/w3c/imsc-hrm-tests">IMSC Hypothetical Render Model (HRM) Tests</a></li>
+        <li><a href="https://github.com/w3c/imsc-hrm-tests/pulse">IMSC Hypothetical Render Model (HRM) Tests</a></li>
         <li><a href="https://github.com/w3c/IMSC-1.0.1_Text_TestContent/pulse">Test contents for IMSC 1.0.1 Text</a></li>
         <li><a href="https://github.com/w3c/IMSC-1.1_Text_TestContent/pulse">Test contents for IMSC 1.1 Text</a></li>
         <li><a href="https://github.com/w3c/IMSC-1.1_Image_TestContent/pulse">Test contents for IMSC 1.1 Image</a></li>

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
       <h3>Recommendation Track specification repositories</h3>
       <ul>
         <li><a href="https://github.com/w3c/imsc/pulse">IMSC</a></li>
-        <li><a href="https://github.com/w3c/imsc-hrm">IMSC Hypothetical Render Model (HRM)</a></li>
+        <li><a href="https://github.com/w3c/imsc-hrm/pulse">IMSC Hypothetical Render Model (HRM)</a></li>
         <li><a href="https://github.com/w3c/ttml1/pulse">TTML1</a></li>
         <li><a href="https://github.com/w3c/ttml2/pulse">TTML2</a></li>
         <li><a href="https://github.com/w3c/webvtt/pulse">WebVTT</a></li>

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ type="submit" /> <a href="https://www.w3.org/2002/02/mail-search-help" class="se
         <li><a href="https://github.com/w3c/adpt/pulse">ADPT</a></li>
       </ul>
       <h2 id="join">How to join the group</h2>
-      <p>This group operates under the <a href="https://www.w3.org/2020/09/15-pp-faq.html">W3C
+      <p>This group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C
           Patent Policy</a>, which ensures that specifications published by the
         group can be implemented on a royalty-free (RF) basis. To record
         agreement from all participants with that W3C Patent Policy, joining the


### PR DESCRIPTION
- link to charter updated
- modified deliverables list, adding section for suspended
- changed several URLs in how to join section (bottom), like patent policy FAQ

any missing todo? (especially for deliverables)